### PR TITLE
Use waste schedule API for calendar events

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import Panel from './Panel';
 import Geocoder from './Geocoder';
 import Cal from './Cal';
+import { buildWasteAPI } from '../utils/WasteAPI';
 import './App.scss';
 import '../../node_modules/leaflet/dist/leaflet.css';
 
@@ -93,7 +94,8 @@ export default class App {
             }
             _app.map.flyTo(tempLocation, 15);
             _app.panel.currentProvider = featureCollection.features[0].properties.contractor;
-            fetch(`https://apis.detroitmi.gov/waste_schedule/details/${featureCollection.features[0].properties.FID}/year/${_app.year}/month/${_app.month}/`)
+            const wasteAPIEndpoint = buildWasteAPI(featureCollection.features[0].properties.FID, _app.year, _app.month);
+            fetch(wasteAPIEndpoint)
             .then((res) => {
                 res.json().then(data => {
                     _app.panel.location.lat = tempLocation.lat;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,15 +11,6 @@ export default class App {
     constructor() {
         this.month = moment().month() + 1;
         this.year = moment().year();
-        this.schedule = {
-            garbage: null,
-            recycle: null,
-            bulk:    null,
-            yard: {
-                start: null,
-                end: null
-            }
-        }
         this.point = null;
         this.map = null;
         this.layers = {};
@@ -105,17 +96,6 @@ export default class App {
             fetch(`https://apis.detroitmi.gov/waste_schedule/details/${featureCollection.features[0].properties.FID}/year/${_app.year}/month/${_app.month}/`)
             .then((res) => {
                 res.json().then(data => {
-                    data.details.forEach((d)=>{
-                        if(d.type == 'start-date' && d.service == 'yard waste'){
-                            _app.schedule.yard.start = d.newDay;
-                        }
-                        if(d.type == 'end-date' && d.service == 'yard waste'){
-                            _app.schedule.yard.end = d.newDay;
-                        }
-                    });
-                    _app.schedule.garbage = data.next_pickups.trash.next_pickup;
-                    _app.schedule.recycle = data.next_pickups.recycling.next_pickup;
-                    _app.schedule.bulk = data.next_pickups.bulk.next_pickup;
                     _app.panel.location.lat = tempLocation.lat;
                     _app.panel.location.lng = tempLocation.lng;
                     _app.panel.data = data;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -18,6 +18,7 @@ export default class App {
         this.calendar = new Cal('calendar', this);;
         this.panel = new Panel(this);
         this.geocoder = new Geocoder('geocoder', this);
+        this.routeNum = null;
         this.initialLoad(this);
     }
 
@@ -94,7 +95,8 @@ export default class App {
             }
             _app.map.flyTo(tempLocation, 15);
             _app.panel.currentProvider = featureCollection.features[0].properties.contractor;
-            const wasteAPIEndpoint = buildWasteAPI(featureCollection.features[0].properties.FID, _app.year, _app.month);
+            _app.routeNum = featureCollection.features[0].properties.FID;
+            const wasteAPIEndpoint = buildWasteAPI(_app.routeNum, _app.year, _app.month);
             fetch(wasteAPIEndpoint)
             .then((res) => {
                 res.json().then(data => {

--- a/src/components/Cal.js
+++ b/src/components/Cal.js
@@ -63,7 +63,7 @@ export default class Cal {
   fetchPickups(info, successCb, failureCb, pickupType, routeNum, eventBuilder) {
     const month = info.start.getMonth() + 1;
     const wasteAPIEndpoint = buildWasteAPI(routeNum, info.start.getFullYear(), month);
-    fetch(wasteAPIEndpoint)
+    fetch(wasteAPIEndpoint, {'cache': 'force-cache'})
     .then((res) => {
       res.json().then((data) => {
         const events = eventBuilder(data, pickupType);

--- a/src/components/Cal.js
+++ b/src/components/Cal.js
@@ -22,7 +22,7 @@ export default class Cal {
     calContainer.id = 'calendar';
     tempCal.innerHTML = `
       <article class='cal-legend'>
-        <span class="garbage">Garbage</span> 
+        <span class="garbage">Garbage</span>
         <span class="recycle">Recycle</span> 
         <span class="bulk">Bulk</span> 
         <span class="yard">Yard</span> 

--- a/src/components/Cal.js
+++ b/src/components/Cal.js
@@ -1,12 +1,12 @@
 import { Calendar } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import moment from 'moment';
+import { buildWasteAPI, PICKUP_TYPES, PICKUP_TYPES_PRINT } from '../utils/WasteAPI';
 import './Cal.scss';
 export default class Cal {
   constructor(container, _controller) {
     this.calendar = null;
     this.controller = _controller;
-    this.pickups = [];
   }
 
   createCalendar(_app){
@@ -30,131 +30,116 @@ export default class Cal {
     `;
     tempCal.appendChild(calContainer);
     tempCal.prepend(closeBtn);
-    _app.calendar.buildSchedule(_app);
     _app.calendar.calendar = new Calendar(calContainer, {
       plugins: [ dayGridPlugin ],
-      eventSources: _app.calendar.pickups
+      showNonCurrentDates: false,
+      eventSources: [
+        {
+          events: this.fetchTrashPickups.bind(this),
+          color: '#cb4d4f',
+          textColor: 'white'
+        },
+        {
+          events: this.fetchRecyclingPickups.bind(this),
+          color: '#9FD5B3',
+          textColor: '#004445'
+        },
+        {
+          events: this.fetchBulkPickups.bind(this),
+          color: '#5f355a',
+          textColor: 'white'
+        },
+        {
+          events: this.fetchYardPickups.bind(this),
+          color: '#feb70d',
+          textColor: 'black'
+        }
+      ],
     });
     _app.calendar.calendar.render();
     document.querySelector('#app .calendar').className = "calendar active";
   }
 
-  buildSchedule(_app){
-    _app.calendar.buildPickUps(_app);
+  fetchPickups(info, successCb, failureCb, pickupType, routeNum, eventBuilder) {
+    const month = info.start.getMonth() + 1;
+    const wasteAPIEndpoint = buildWasteAPI(routeNum, info.start.getFullYear(), month);
+    fetch(wasteAPIEndpoint)
+    .then((res) => {
+      res.json().then((data) => {
+        const events = eventBuilder(data, pickupType);
+        successCb(events);
+      })
+    })
+    .catch((error) => {
+      console.error(error);
+      failureCb(error);
+    });
   }
 
-  buildPickUps(_app){
-    let pastDate = _app.schedule.recycle;
-    let latestDate = _app.schedule.recycle;
-    let pastTrashDate = _app.schedule.garbage;
-    let trashDate = _app.schedule.garbage;
+  fetchTrashPickups(info, successCb, failureCb) {
+    this.fetchPickups(
+      info,
+      successCb,
+      failureCb,
+      PICKUP_TYPES.TRASH,
+      this.controller.routeNum,
+      this.buildPickUps
+    );
+  }
 
-    let gList = {
-      events: [
-        {
-          title  : 'Trash',
-          start  : moment(trashDate).format('YYYY-MM-DD'),
-        }
-      ],
-      color: '#cb4d4f',     // an option!
-      textColor: 'white' // an option!
-    };
-    let rList = {
-      events: [
-        {
-          title  : 'Recycle',
-          start  : moment(latestDate).format('YYYY-MM-DD'),
-        }
-      ],
-      color: '#9FD5B3',     // an option!
-      textColor: '#004445' // an option!
-    };
-    let bList = {
-      events: [
-        {
-          title  : 'Bulk',
-          start  : moment(latestDate).format('YYYY-MM-DD'),
-        }
-      ],
-      color: '#5f355a',     // an option!
-      textColor: 'white' // an option!
-    };
-    let yList = {
-      events: [],
-      color: '#feb70d',     // an option!
-      textColor: 'black' // an option!
-    }
-    if(moment(latestDate).isBetween(_app.schedule.yard.start, _app.schedule.yard.end)){
-      yList.events.push(
-        {
-          title  : 'Yard',
-          start  : moment(latestDate).format('YYYY-MM-DD'),
-        }
-      );
-    }
-    for (let index = 0; index < 52; index++) {
-      let tempG = {
-        title  : 'Trash',
-        start  : moment(trashDate).add(7,'d').format('YYYY-MM-DD'),
-      };
-      let pasttempG = {
-        title  : 'Trash',
-        start  : moment(pastTrashDate).subtract(7,'d').format('YYYY-MM-DD'),
-      };
-      trashDate = moment(trashDate).add(7,'d');
-      pastTrashDate = moment(pastTrashDate).subtract(7,'d');
-      gList.events.push(tempG);
-      gList.events.push(pasttempG);
-    }
+  fetchRecyclingPickups(info, successCb, failureCb) {
+    this.fetchPickups(
+      info,
+      successCb,
+      failureCb,
+      PICKUP_TYPES.RECYCLING,
+      this.controller.routeNum,
+      this.buildPickUps
+    );
+  }
 
-    for (let index = 0; index < 26; index++) {
-      let tempR = {
-        title  : 'Recycle',
-        start  : moment(latestDate).add(14,'d').format('YYYY-MM-DD'),
-      };
-      let tempB = {
-        title  : 'Bulk',
-        start  : moment(latestDate).add(14,'d').format('YYYY-MM-DD'),
-      };
-      if(moment(latestDate).add(14,'d').isBetween(_app.schedule.yard.start, _app.schedule.yard.end)){
-        let tempY = {
-          title  : 'Yard',
-          start  : moment(latestDate).add(14,'d').format('YYYY-MM-DD'),
-        };
-        yList.events.push(tempY);
+  fetchYardPickups(info, successCb, failureCb) {
+    this.fetchPickups(
+      info,
+      successCb,
+      failureCb,
+      PICKUP_TYPES.YARD_WASTE,
+      this.controller.routeNum,
+      this.buildPickUps
+    );
+  }
+
+  fetchBulkPickups(info, successCb, failureCb) {
+    this.fetchPickups(
+      info,
+      successCb,
+      failureCb,
+      PICKUP_TYPES.BULK,
+      this.controller.routeNum,
+      this.buildPickUps
+    );
+  }
+
+  buildPickUps(eventData, pickupType){
+    let events = [];
+    eventData.schedule.forEach((pickupDateDetails) => {
+      for (const [pickupDate, pickupTypeDetails] of Object.entries(pickupDateDetails)) {
+        if (pickupType in pickupTypeDetails) {
+          events.push(
+            {
+              title  : PICKUP_TYPES_PRINT[pickupType],
+              start  : moment(pickupDate).format('YYYY-MM-DD'),
+            }
+          );
+        }
       }
-      let pasttempR = {
-        title  : 'Recycle',
-        start  : moment(pastDate).subtract(14,'d').format('YYYY-MM-DD'),
-      };
-      let pasttempB = {
-        title  : 'Bulk',
-        start  : moment(pastDate).subtract(14,'d').format('YYYY-MM-DD'),
-      };
-      if(moment(pastDate).subtract(14,'d').isBetween(_app.schedule.yard.start, _app.schedule.yard.end)){
-        let pasttempY = {
-          title  : 'Yard',
-          start  : moment(pastDate).subtract(14,'d').format('YYYY-MM-DD'),
-        };
-        yList.events.push(pasttempY);
-      }
-      pastDate = moment(pastDate).subtract(14,'d');
-      latestDate = moment(latestDate).add(14,'d');
-      rList.events.push(tempR);
-      bList.events.push(tempB);
-      rList.events.push(pasttempR);
-      bList.events.push(pasttempB);
-    }
-    _app.calendar.pickups.push(gList);
-    _app.calendar.pickups.push(rList);
-    _app.calendar.pickups.push(bList);
-    _app.calendar.pickups.push(yList);
+    });
+    return events;
   }
 
   closeCalendar(ev,_calendar){
     _calendar.calendar.destroy();
     _calendar.calendar = null;
-    _calendar.pickups.length = 0;
     let tempClass = ev.target.parentNode.parentNode.className;
     tempClass = tempClass.split(' ');
     ev.target.parentNode.parentNode.className = tempClass[0];

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -122,18 +122,8 @@ export default class Panel {
         document.querySelector('#app .panel').className = "panel active";
     }
     
-    checkRecyclingStatus(_panel){
-        if(_panel.data.next_pickups['yard waste']){
-            if(moment(_panel.data.next_pickups['yard waste'].next_pickup).isBetween(_panel.app.schedule.yard.start, _panel.app.schedule.yard.end)){
-                return true;
-            }else{
-                return false;
-            }
-        }else{
-            return false;
-        }
-    }
-    
+    // TODO: Stop using next_pickups from API:
+    // https://github.com/CityOfDetroit/dpw-map/issues/53
     buildNextPickup(_panel){
         return `
         
@@ -155,7 +145,7 @@ export default class Panel {
             <span class="header">BULK</span>
             <p>${moment(_panel.data.next_pickups.bulk.next_pickup).format('dddd - MMM Do')}</p>
         </div>
-        ${(_panel.checkRecyclingStatus(_panel)) ? `
+        ${('yard waste' in _panel.data.next_pickups) ? `
         <div class="group">
             <span class="header">YARD</span>
             <p>${moment(_panel.data.next_pickups['yard waste'].next_pickup).format('dddd - MMM Do')}</p>

--- a/src/utils/WasteAPI.js
+++ b/src/utils/WasteAPI.js
@@ -17,10 +17,10 @@ const PICKUP_TYPES = Object.freeze({
 });
 
 const PICKUP_TYPES_PRINT = Object.freeze({
-  "trash": "Trash",
-  "recycling": "Recycling",
+  "trash": "Garbage",
+  "recycling": "Recycle",
   "bulk": "Bulk",
-  "yard waste": "Yard Waste"
+  "yard waste": "Yard"
 });
 
 export {buildWasteAPI, PICKUP_TYPES, PICKUP_TYPES_PRINT};

--- a/src/utils/WasteAPI.js
+++ b/src/utils/WasteAPI.js
@@ -9,4 +9,18 @@ function buildWasteAPI(routeNum, year, month) {
   return `https://apis.detroitmi.gov/waste_schedule/details/${routeNum}/year/${year}/month/${month}/`;
 }
 
-export {buildWasteAPI};
+const PICKUP_TYPES = Object.freeze({
+  TRASH:      "trash",
+  RECYCLING:  "recycling",
+  BULK:       "bulk",
+  YARD_WASTE: "yard waste"
+});
+
+const PICKUP_TYPES_PRINT = Object.freeze({
+  "trash": "Trash",
+  "recycling": "Recycling",
+  "bulk": "Bulk",
+  "yard waste": "Yard Waste"
+});
+
+export {buildWasteAPI, PICKUP_TYPES, PICKUP_TYPES_PRINT};

--- a/src/utils/WasteAPI.js
+++ b/src/utils/WasteAPI.js
@@ -1,0 +1,12 @@
+/**
+ * Returns the API endpoint for the City of Detroit Waste Schedule API.
+ * @param {number} routeNum - The number denoting the waste pickup route.
+ * @param {string} year - The year formatted as YYYY.
+ * @param {string} month - The month formatted as MM and 1-indexed.
+ * @returns {string} - A REST API endpoint URL.
+ */
+function buildWasteAPI(routeNum, year, month) {
+  return `https://apis.detroitmi.gov/waste_schedule/details/${routeNum}/year/${year}/month/${month}/`;
+}
+
+export {buildWasteAPI};


### PR DESCRIPTION
## This PR Fixes #52 

See #52 for context. The goal of this PR is to replace the datetime logic for calculating future DPW pickups with the waste schedule API which handles holidays and service changes on the backend.

This PR does a few things to accomplish that:
1. Introduce a utils for the waste schedule API to reduce duplicate code and make JSON keys consistent
2. Stop storing a separate schedule on the app object for each pickup type
3. Store the waste pickup route number from AGO API result so it can be used in the calendar component for waste schedule API queries
4. Use [`eventSources`](https://fullcalendar.io/docs/event-source) and [`events (as a function)`](https://fullcalendar.io/docs/events-function) to query the pickup schedule for each calendar view loaded
    * NOTE: If you read the code, it seems like we're querying the waste schedule API 5 times for the current month when someone opens the calendar (once on app load, then once for each of trash, recycling, bulk, and yard) however since we're using [`force-cache`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#cache) option, the `fetch` call just grabs the response from the cache instead since the request is identical. Ideally, we wouldn't have to do this because `default` cache option should use the HTTP cache as well but I don't think we're setting cache headers on the API response so this doesn't work.
6. Disable days outside the current month from showing to make it easier to reason about which month of pickups to fetch
7. Update panel component to check whether to display yard waste in layout based on the presence of yard waste in the waste schedule API response `next_pickup` object instead of deducing the same info in client-side code based on yard waste start/end data

## Testing

Load the app locally and test various routes and interactions:


https://github.com/CityOfDetroit/dpw-map/assets/143553259/139f4aef-f618-4ea5-9c24-d8ae26ea1edc

